### PR TITLE
Fix Android compilation error with RN 0.47

### DIFF
--- a/android/src/main/java/com/clipsub/rnbottomsheet/RNBottomSheetPackage.java
+++ b/android/src/main/java/com/clipsub/rnbottomsheet/RNBottomSheetPackage.java
@@ -26,11 +26,6 @@ public class RNBottomSheetPackage implements ReactPackage {
     }
 
     @Override
-    public List<Class<? extends JavaScriptModule>> createJSModules() {
-        return Collections.emptyList();
-    }
-
-    @Override
     public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
         return Collections.emptyList();
     }


### PR DESCRIPTION
Method createJSModules was removed from RN 0.47. Which leads to compilation error due to @override annotation. This method can be removed right now (https://github.com/facebook/react-native/issues/15232)