### PR TITLE
Allow only one active bottomsheet on android

### DIFF
--- a/android/src/main/java/com/clipsub/rnbottomsheet/RNBottomSheet.java
+++ b/android/src/main/java/com/clipsub/rnbottomsheet/RNBottomSheet.java
@@ -23,6 +23,7 @@ import java.util.List;
 
 public class RNBottomSheet extends ReactContextBaseJavaModule {
 
+    private static boolean isOpened = false;
     private Callback shareSuccessCallback;
     private Callback shareFailureCallback;
 
@@ -37,6 +38,10 @@ public class RNBottomSheet extends ReactContextBaseJavaModule {
 
     @ReactMethod
     public void showBottomSheetWithOptions(ReadableMap options, final Callback onSelect) {
+        if (RNBottomSheet.isOpened) return;
+
+        RNBottomSheet.isOpened = true;
+
         ReadableArray optionArray = options.getArray("options");
         final Integer cancelButtonIndex = options.getInt("cancelButtonIndex");
         String title;
@@ -75,6 +80,13 @@ public class RNBottomSheet extends ReactContextBaseJavaModule {
                 } else {
                     onSelect.invoke(which);
                 }
+            }
+        });
+
+        builder.setOnDismissListener(new DialogInterface.OnDismissListener() {
+            @Override
+            public void onDismiss(DialogInterface dialog) {
+                RNBottomSheet.isOpened = false;
             }
         });
 

--- a/android/src/main/java/com/clipsub/rnbottomsheet/RNBottomSheet.java
+++ b/android/src/main/java/com/clipsub/rnbottomsheet/RNBottomSheet.java
@@ -23,7 +23,7 @@ import java.util.List;
 
 public class RNBottomSheet extends ReactContextBaseJavaModule {
 
-    private static boolean isOpened = false;
+    private boolean isOpened;
     private Callback shareSuccessCallback;
     private Callback shareFailureCallback;
 
@@ -38,9 +38,9 @@ public class RNBottomSheet extends ReactContextBaseJavaModule {
 
     @ReactMethod
     public void showBottomSheetWithOptions(ReadableMap options, final Callback onSelect) {
-        if (RNBottomSheet.isOpened) return;
+        if (this.isOpened) return;
 
-        RNBottomSheet.isOpened = true;
+        this.isOpened = true;
 
         ReadableArray optionArray = options.getArray("options");
         final Integer cancelButtonIndex = options.getInt("cancelButtonIndex");
@@ -86,7 +86,7 @@ public class RNBottomSheet extends ReactContextBaseJavaModule {
         builder.setOnDismissListener(new DialogInterface.OnDismissListener() {
             @Override
             public void onDismiss(DialogInterface dialog) {
-                RNBottomSheet.isOpened = false;
+                RNBottomSheet.this.isOpened = false;
             }
         });
 


### PR DESCRIPTION
On iOS there is only one possible active bottom sheet. On android there can be multiple stacked bottom sheets. Using not very elegant flag this PR fixes the issue by allowing only one bottom sheet to be visible.