### PR TITLE
Dismiss sheet on select

### DIFF
--- a/android/src/main/java/com/clipsub/rnbottomsheet/RNBottomSheet.java
+++ b/android/src/main/java/com/clipsub/rnbottomsheet/RNBottomSheet.java
@@ -75,9 +75,8 @@ public class RNBottomSheet extends ReactContextBaseJavaModule {
         builder.listener(new DialogInterface.OnClickListener() {
             @Override
             public void onClick(DialogInterface dialog, int which) {
-                if (which == cancelButtonIndex) {
-                    dialog.dismiss();
-                } else {
+                dialog.dismiss();
+                if (which != cancelButtonIndex) {
                     onSelect.invoke(which);
                 }
             }


### PR DESCRIPTION
After my last PR we've encountered a case when we want to open a new sheet from the option in the current sheet and it isn't possible. This PR is fixing this by dismissing the sheet before invoking `onSelect` ;)