### PR TITLE
Add onSelect callback for dismiss button #android

### DIFF
--- a/android/src/main/java/com/clipsub/rnbottomsheet/RNBottomSheet.java
+++ b/android/src/main/java/com/clipsub/rnbottomsheet/RNBottomSheet.java
@@ -86,6 +86,7 @@ public class RNBottomSheet extends ReactContextBaseJavaModule {
             @Override
             public void onDismiss(DialogInterface dialog) {
                 RNBottomSheet.this.isOpened = false;
+                onSelect.invoke(cancelButtonIndex);
             }
         });
 


### PR DESCRIPTION
## Scenario
When I click `Cancel`, it will hide the dialog, but it will not call the `callback` with index. 
In my code, I need to also use callback on cancel, to reset state.

## Test code
```js
BottomSheet.showBottomSheetWithOptions({
  options: ['Cancel', 'Show something cool'],
  cancelButtonIndex: 0,
},
index => console.log(index)
});
```