### PR TITLE
fix double callback invocation

### DIFF
--- a/android/src/main/java/com/clipsub/rnbottomsheet/RNBottomSheet.java
+++ b/android/src/main/java/com/clipsub/rnbottomsheet/RNBottomSheet.java
@@ -76,9 +76,7 @@ public class RNBottomSheet extends ReactContextBaseJavaModule {
             @Override
             public void onClick(DialogInterface dialog, int which) {
                 dialog.dismiss();
-                if (which != cancelButtonIndex) {
-                    onSelect.invoke(which);
-                }
+                onSelect.invoke(which);
             }
         });
 
@@ -86,7 +84,6 @@ public class RNBottomSheet extends ReactContextBaseJavaModule {
             @Override
             public void onDismiss(DialogInterface dialog) {
                 RNBottomSheet.this.isOpened = false;
-                onSelect.invoke(cancelButtonIndex);
             }
         });
 


### PR DESCRIPTION
Remove condition and use `callback.invoke()` just once, since RN doesn't allow dobuel invocation: https://facebook.github.io/react-native/docs/native-modules-ios#callbacks

> A native module should invoke its callback exactly once. It's okay to store the callback and invoke it later. This pattern is often used to wrap iOS APIs that require delegates - see RCTAlertManager for an example. If the callback is never invoked, some memory is leaked. If both onSuccess and onFail callbacks are passed, you should only invoke one of them.